### PR TITLE
Replaces the deprecated block_categories filter

### DIFF
--- a/src/init.php
+++ b/src/init.php
@@ -67,7 +67,7 @@ function aab_blocks_new_cat( $categories ){
 		)
 	);
 }
-add_filter( 'block_categories', 'aab_blocks_new_cat' );
+add_filter( 'block_categories_all', 'aab_blocks_new_cat' );
 
 /**
  * External Assets


### PR DESCRIPTION
Replaces block_categories filter since it was was deprecated in WordPress 5.8
https://gist.github.com/gziolo/a947dc52eb2604c77a0a5b0797b2e781#block_categories_all